### PR TITLE
fix: mark partition as finished before checking children in ImmutableKeyRange mode

### DIFF
--- a/changestreams/reader.go
+++ b/changestreams/reader.go
@@ -448,6 +448,8 @@ func (r *Reader) startRead(ctx context.Context, partitionToken string, startTime
 			return err
 		}
 
+		r.markStateFinished(partitionToken)
+
 		for _, childPartitionsRecord := range childPartitionRecords {
 			childStartTimestamp := childPartitionsRecord.StartTimestamp
 			for _, childPartition := range childPartitionsRecord.ChildPartitions {


### PR DESCRIPTION
fix: https://github.com/cloudspannerecosystem/spanner-change-streams-tail/issues/28