### PR TITLE
feat: allow providing an existing Spanner client via Config

### DIFF
--- a/changestreams/reader.go
+++ b/changestreams/reader.go
@@ -171,11 +171,11 @@ type Config struct {
 	// If StartTimestamp is a zero value of time.Time, reader reads from the current timestamp.
 	StartTimestamp time.Time
 	// If EndTimestamp is a zero value of time.Time, reader reads until it is cancelled.
-	EndTimestamp time.Time
+	EndTimestamp      time.Time
+	HeartbeatInterval time.Duration
 	// SpannerClient, if set, is reused instead of creating a new *spanner.Client.
 	// The caller keeps ownership of it: Close does not close a client provided this way.
 	SpannerClient        *spanner.Client
-	HeartbeatInterval    time.Duration
 	SpannerClientConfig  spanner.ClientConfig
 	SpannerClientOptions []option.ClientOption
 }

--- a/changestreams/reader.go
+++ b/changestreams/reader.go
@@ -154,6 +154,7 @@ const (
 // Reader is the change stream reader.
 type Reader struct {
 	client            *spanner.Client
+	ownsClient        bool
 	streamID          string
 	startTimestamp    time.Time
 	endTimestamp      time.Time
@@ -170,7 +171,10 @@ type Config struct {
 	// If StartTimestamp is a zero value of time.Time, reader reads from the current timestamp.
 	StartTimestamp time.Time
 	// If EndTimestamp is a zero value of time.Time, reader reads until it is cancelled.
-	EndTimestamp         time.Time
+	EndTimestamp time.Time
+	// SpannerClient, if set, is reused instead of creating a new *spanner.Client.
+	// The caller keeps ownership of it: Close does not close a client provided this way.
+	SpannerClient        *spanner.Client
 	HeartbeatInterval    time.Duration
 	SpannerClientConfig  spanner.ClientConfig
 	SpannerClientOptions []option.ClientOption
@@ -187,10 +191,16 @@ func NewReader(ctx context.Context, projectID, instanceID, databaseID, streamID 
 
 // NewReaderWithConfig creates a new reader with a given configuration.
 func NewReaderWithConfig(ctx context.Context, projectID, instanceID, databaseID, streamID string, config Config) (*Reader, error) {
-	dbPath := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, databaseID)
-	client, err := spanner.NewClientWithConfig(ctx, dbPath, config.SpannerClientConfig, config.SpannerClientOptions...)
-	if err != nil {
-		return nil, err
+	client := config.SpannerClient
+	ownsClient := false
+	if client == nil {
+		dbPath := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, databaseID)
+		var err error
+		client, err = spanner.NewClientWithConfig(ctx, dbPath, config.SpannerClientConfig, config.SpannerClientOptions...)
+		if err != nil {
+			return nil, err
+		}
+		ownsClient = true
 	}
 
 	dialect, err := detectDialect(ctx, client)
@@ -210,6 +220,7 @@ func NewReaderWithConfig(ctx context.Context, projectID, instanceID, databaseID,
 
 	return &Reader{
 		client:            client,
+		ownsClient:        ownsClient,
 		streamID:          streamID,
 		startTimestamp:    config.StartTimestamp,
 		endTimestamp:      config.EndTimestamp,
@@ -221,8 +232,13 @@ func NewReaderWithConfig(ctx context.Context, projectID, instanceID, databaseID,
 }
 
 // Close closes the reader.
+//
+// If the reader was created with an externally provided Config.SpannerClient,
+// Close does not close that client — the caller retains ownership of it.
 func (r *Reader) Close() {
-	r.client.Close()
+	if r.ownsClient {
+		r.client.Close()
+	}
 }
 
 // Read starts reading the change stream.


### PR DESCRIPTION
## Context
`NewReaderWithConfig` always creates its own `*spanner.Client` via
`spanner.NewClientWithConfig`, with no way to reuse a client the
caller already has.

## What
`Config` now has an optional `SpannerClient *spanner.Client` field.
When set, the reader uses it instead of creating a new one. `Close`
only closes the client when the reader created it itself, so a
caller-provided client's lifecycle stays with the caller.

## Why
Integrating this library into a service that already manages a shared
Spanner client (connection pooling, or the service also runs regular
queries against the same database) currently forces a second,
redundant client. Reusing the existing client avoids that.

## Completion Criteria
- [x] `go build ./...` and `go vet ./...` pass
- [x] `go test ./changestreams/...` passes
- [x] Backwards compatible: `Config.SpannerClient` is optional, existing
  callers using `NewReader`/`NewReaderWithConfig` without it are unaffected

close #6